### PR TITLE
Fix symlinks in tar.gz extracted as zero-length files

### DIFF
--- a/recipes-tests/src/test/kotlin/SetupNodeTest.kt
+++ b/recipes-tests/src/test/kotlin/SetupNodeTest.kt
@@ -1,0 +1,40 @@
+import io.kotest.matchers.shouldBe
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.isSymbolicLink
+
+class SetupNodeTest : RecipeTest() {
+
+    override val scriptPath: String = "../src/setup-node/src.main.kts"
+
+    init {
+        "should install node and preserve symlinks".config(
+            enabled = !System.getProperty("os.name").lowercase().contains("windows")
+        ) {
+            // arrange
+            val dir = tempDir(name = "node")
+            val version = "22.13.1"
+
+            // act
+            val result = readScript()
+                .withInput("version", version)
+                .withInput("installation_path", dir.absolutePathString())
+                .eval()
+
+            // assert
+            result.shouldHaveZeroExitCode()
+
+            // Node.js tar.gz distributions contain symlinks in bin/
+            // e.g. bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js
+            val nodeDir = dir.toFile().listFiles()
+                ?.firstOrNull { it.name.startsWith("node-v$version") }
+                ?: error("Node directory not found in ${dir}")
+            val binDir = nodeDir.toPath().resolve("bin")
+
+            val npm = binDir.resolve("npm")
+            npm.isSymbolicLink() shouldBe true
+
+            val npx = binDir.resolve("npx")
+            npx.isSymbolicLink() shouldBe true
+        }
+    }
+}

--- a/src/setup-node/src.main.kts
+++ b/src/setup-node/src.main.kts
@@ -241,9 +241,18 @@ object Unpack {
 
         TarArchiveInputStream(GzipCompressorInputStream(FileInputStream(tarGzFile))).use { tar ->
             generateSequence { tar.nextEntry }.forEach { entry ->
-                unpackArchiveEntry(entry, outputDir) { file ->
-                    file.outputStream().use { out -> tar.copyTo(out) }
-                    file.setFilePermissions(entry.mode)
+                val outFile = outputDir.resolveUnpackLocation(entry.name)
+                when {
+                    entry.isDirectory -> outFile.mkdirs()
+                    entry.isSymbolicLink -> {
+                        outFile.parentFile?.mkdirs()
+                        Files.createSymbolicLink(outFile.toPath(), Path.of(entry.linkName))
+                    }
+                    else -> {
+                        outFile.parentFile?.mkdirs()
+                        outFile.outputStream().use { out -> tar.copyTo(out) }
+                        outFile.setFilePermissions(entry.mode)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Symlink entries in tar.gz archives (e.g. Node.js `bin/npm -> ../lib/node_modules/npm/bin/npm-cli.js`) were extracted as zero-length regular files, breaking the Node.js installation on Linux/Mac
- `unpackTarGz` now checks `TarArchiveEntry.isSymbolicLink` and creates actual symlinks via `Files.createSymbolicLink`
- Added `SetupNodeTest` that installs Node.js and verifies `bin/npm` and `bin/npx` are real symbolic links

## Test plan
- [x] `SetupNodeTest` fails before the fix (symlinks extracted as zero-length files)
- [x] `SetupNodeTest` passes after the fix
- [ ] Verify on Linux CI that symlinks are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)